### PR TITLE
Add ML Kit card number recognizer and instrumented test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ local.properties
 .DS_Store
 *.iml
 .idea/
+
+# Test assets
+app/src/androidTest/assets/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,10 +45,14 @@ dependencies {
     implementation "androidx.camera:camera-view:$camerax_version"
 
     implementation 'com.google.mlkit:text-recognition:16.0.0'
+    implementation 'com.google.android.gms:play-services-tasks:18.0.2'
 
     implementation 'com.squareup.retrofit2:retrofit:2.11.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 
     implementation 'com.google.ar:core:1.44.0'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:core:1.5.0'
 }

--- a/app/src/androidTest/java/com/example/pokescanner/ocr/CardNumberRecognizerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/pokescanner/ocr/CardNumberRecognizerInstrumentedTest.kt
@@ -1,0 +1,31 @@
+package com.example.pokescanner.ocr
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CardNumberRecognizerInstrumentedTest {
+    @Test
+    fun recognizeNumberFromGeneratedBitmap() {
+        val width = 200
+        val height = 200
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
+        val paint = Paint().apply {
+            color = Color.BLACK
+            textSize = 48f
+        }
+        canvas.drawText("123/456", 20f, height - 10f, paint)
+
+        val result = CardNumberRecognizer.recognize(bitmap)
+        assertEquals("123/456", result)
+    }
+}
+

--- a/app/src/main/java/com/example/pokescanner/ocr/CardNumberRecognizer.kt
+++ b/app/src/main/java/com/example/pokescanner/ocr/CardNumberRecognizer.kt
@@ -1,0 +1,104 @@
+package com.example.pokescanner.ocr
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import com.google.android.gms.tasks.Tasks
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+
+/**
+ * Uses ML Kit to recognize the card number located at the bottom of a frame.
+ * The number must match the pattern \d{1,3}/\d{1,3}.
+ */
+class CardNumberRecognizer(
+    private val context: Context,
+    private val lifecycleOwner: LifecycleOwner,
+    private val previewView: PreviewView,
+    private val onCardNumberFound: (String) -> Unit
+) {
+    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    private val pattern = Regex("\\d{1,3}/\\d{1,3}")
+
+    fun start() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            val preview = Preview.Builder().build().apply {
+                setSurfaceProvider(previewView.surfaceProvider)
+            }
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+            analysis.setAnalyzer(ContextCompat.getMainExecutor(context)) { image ->
+                processImage(image)
+            }
+            val selector = CameraSelector.DEFAULT_BACK_CAMERA
+            cameraProvider.unbindAll()
+            cameraProvider.bindToLifecycle(lifecycleOwner, selector, preview, analysis)
+        }, ContextCompat.getMainExecutor(context))
+    }
+
+    fun stop() {
+        val provider = ProcessCameraProvider.getInstance(context).get()
+        provider.unbindAll()
+    }
+
+    private fun processImage(imageProxy: ImageProxy) {
+        val mediaImage = imageProxy.image
+        if (mediaImage != null) {
+            val rotation = imageProxy.imageInfo.rotationDegrees
+            val input = InputImage.fromMediaImage(mediaImage, rotation)
+            val bitmap = input.bitmapInternal
+            if (bitmap != null) {
+                val number = detectNumberFromBitmap(bitmap)
+                if (number != null) {
+                    onCardNumberFound(number)
+                }
+            }
+        }
+        imageProxy.close()
+    }
+
+    private fun cropBottom(bitmap: Bitmap): Bitmap {
+        val cropHeight = (bitmap.height * 0.25).toInt()
+        return Bitmap.createBitmap(bitmap, 0, bitmap.height - cropHeight, bitmap.width, cropHeight)
+    }
+
+    /**
+     * Detects a card number from the provided bitmap.
+     * This method is synchronous and blocks until ML Kit finishes.
+     */
+    fun detectNumberFromBitmap(bitmap: Bitmap): String? {
+        val cropped = cropBottom(bitmap)
+        val result = Tasks.await(
+            recognizer.process(InputImage.fromBitmap(cropped, 0))
+        )
+        return pattern.find(result.text)?.value
+    }
+
+    companion object {
+        /**
+         * Utility function for tests: recognize card number from a bitmap without instantiating CameraX.
+         */
+        fun recognize(bitmap: Bitmap): String? {
+            val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+            val pattern = Regex("\\d{1,3}/\\d{1,3}")
+            val cropHeight = (bitmap.height * 0.25).toInt()
+            val cropped = Bitmap.createBitmap(bitmap, 0, bitmap.height - cropHeight, bitmap.width, cropHeight)
+            val result = Tasks.await(
+                recognizer.process(InputImage.fromBitmap(cropped, 0))
+            )
+            return pattern.find(result.text)?.value
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement CardNumberRecognizer using CameraX and ML Kit to detect card numbers
- add instrumentation test with sample image
- configure tasks and Android test dependencies
- replace binary test asset with programmatically generated bitmap and ignore test assets

## Testing
- `gradle test` *(fails: SDK location not found)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8f8861888333b4bfc94d3e2e9073