### PR TITLE
feat: add price overlay renderer

### DIFF
--- a/app/src/main/java/com/example/pokescanner/ar/PriceOverlayRenderer.kt
+++ b/app/src/main/java/com/example/pokescanner/ar/PriceOverlayRenderer.kt
@@ -1,0 +1,100 @@
+package com.example.pokescanner.ar
+
+import android.content.Context
+import android.graphics.Rect
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupMenu
+import android.widget.TextView
+import com.example.pokescanner.R
+import com.google.ar.core.ArCoreApk
+import com.google.ar.core.Session
+
+/**
+ * Renders a price overlay aligned with a detected card.
+ * Uses ARCore when available; otherwise falls back to a 2D overlay.
+ */
+class PriceOverlayRenderer(
+    private val context: Context,
+    private val container: ViewGroup,
+    private val onFavorite: (() -> Unit)? = null,
+    private val onShare: (() -> Unit)? = null
+) {
+
+    private var arSession: Session? = null
+    private var overlayView: View? = null
+
+    init {
+        setupSession()
+    }
+
+    private fun setupSession() {
+        val availability = ArCoreApk.getInstance().checkAvailability(context)
+        if (availability.isSupported) {
+            try {
+                arSession = Session(context)
+            } catch (_: Exception) {
+                arSession = null
+            }
+        }
+    }
+
+    /** Aligns overlay to [cardBounds] and displays [price]. */
+    fun render(cardBounds: Rect, price: String) {
+        val overlay = overlayView ?: createOverlay()
+        overlay.findViewById<TextView>(R.id.price_text).text = price
+
+        val params = ViewGroup.MarginLayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ).apply {
+            leftMargin = cardBounds.left
+            topMargin = cardBounds.top
+        }
+        overlay.layoutParams = params
+        overlay.visibility = View.VISIBLE
+
+        arSession?.let {
+            try {
+                // ARCore session update to keep tracking
+                it.update()
+            } catch (_: Exception) {
+                // Ignore update failures; overlay still renders in 2D
+            }
+        }
+    }
+
+    /** Updates only the price value on the overlay. */
+    fun updatePrice(newPrice: String) {
+        overlayView?.findViewById<TextView>(R.id.price_text)?.text = newPrice
+    }
+
+    fun hide() {
+        overlayView?.visibility = View.GONE
+    }
+
+    private fun createOverlay(): View {
+        val view = LayoutInflater.from(context)
+            .inflate(R.layout.view_price_overlay, container, false)
+        view.setOnClickListener { showPopup(it) }
+        container.addView(view)
+        overlayView = view
+        return view
+    }
+
+    private fun showPopup(anchor: View) {
+        val popup = PopupMenu(context, anchor)
+        popup.menu.add("Favoritar")
+        popup.menu.add("Compartilhar")
+        popup.setOnMenuItemClickListener { item ->
+            when (item.title) {
+                "Favoritar" -> onFavorite?.invoke()
+                "Compartilhar" -> onShare?.invoke()
+            }
+            true
+        }
+        popup.show()
+    }
+}
+

--- a/app/src/main/res/layout/view_price_overlay.xml
+++ b/app/src/main/res/layout/view_price_overlay.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="#CC000000"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/price_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/white"
+        android:textSize="16sp"
+        android:text="--" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- render price overlay aligned to card detection using ARCore when supported
- add touch interactions to favorite or share card details

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd99aacc8333b3ff893ab218795d